### PR TITLE
refactor: use whiskers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,30 +36,16 @@
 
 ## Usage
 
-### Installation
-
-#### Manual <kbd>(Linux/MacOS)</kbd>
-
-```bash
-git clone https://github.com/catppuccin/geany
-cd geany/src
-mkdir ~/.config/geany/colorschemes/
-cp *.conf ~/.config/geany/colorschemes/
-```
-#### Windows installation <kbd>(Manual)</kbd>
-* Download or clone this repository (`git clone https://github.com/catppuccin/geany`)
-* Open ***File Explorer*** as Administrator
-* Go to the `src` folder then copy <kbd>catppuccin-*flavour*.conf</kbd> to `C:\Program Files\Geany\data\colorschemes\`
-
-### Apply
-
-1. Open Geany
-2. Go to the `view` tab >> `Change color scheme` >> pick your desired `Catppuccin Flavour`
+1. Copy your preferred flavor(s) from [`src/`](./src/) to either `~/.config/geany/colorschemes/` on macOS/Linux or `C:\Program Files\Geany\data\colorschemes\` on Windows.
+2. Open Geany.
+3. Go to **View** > **Change color scheme**.
+4. Select your new Catppuccin flavor!
 
 ## 💝 Thanks to
 
--   [Waxxx333 ](https://github.com/Waxxx333)
--   [Isabelincorp ](https://github.com/isabelincorp)
+- [Waxxx333 ](https://github.com/Waxxx333)
+- [Isabelincorp ](https://github.com/isabelincorp)
+
 &nbsp;
 
 <p align="center"><img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/footers/gray0_ctp_on_line.svg?sanitize=true" /></p>

--- a/geany.tera
+++ b/geany.tera
@@ -1,3 +1,10 @@
+---
+whiskers:
+  version: "2.2.0"
+  matrix:
+    - flavor
+  filename: "src/catppuccin-{{ flavor.identifier }}.conf"
+---
 #
 #  catppuccin.conf
 #
@@ -5,39 +12,16 @@
 #  Reference the filetypes files before editing this config file.
 #
 [theme_info]
-name=Catppuccin Mocha
+name=Catppuccin {{ flavor.name }}
 description=Soothing pastel theme for Geany
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24
 
 [named_colors]
-rosewater=#f5e0dc
-flamingo=#f2cdcd
-pink=#f5c2e7
-mauve=#cba6f7
-red=#f38ba8
-maroon=#eba0ac
-peach=#fab387
-yellow=#f9e2af
-green=#a6e3a1
-teal=#94e2d5
-sky=#89dceb
-sapphire=#74c7ec
-blue=#89b4fa
-lavender=#b4befe
-text=#cdd6f4
-subtext1=#bac2de
-subtext0=#a6adc8
-overlay2=#9399b2
-overlay1=#7f849c
-overlay0=#6c7086
-surface2=#585b70
-surface1=#45475a
-surface0=#313244
-base=#1e1e2e
-mantle=#181825
-crust=#11111b
+{%- for _, color in flavor.colors %}
+{{ color.identifier }}=#{{ color.hex }}
+{%- endfor %}
 
 [named_styles]
 operator=blue

--- a/geany.tera
+++ b/geany.tera
@@ -13,7 +13,7 @@ whiskers:
 #
 [theme_info]
 name=Catppuccin {{ flavor.name }}
-description=Soothing pastel theme for Geany
+description=Soothing pastel theme for the high-spirited!
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers geany.tera

--- a/src/catppuccin-frappe.conf
+++ b/src/catppuccin-frappe.conf
@@ -6,7 +6,7 @@
 #
 [theme_info]
 name=Catppuccin Frappé
-description=Soothing pastel theme for Geany
+description=Soothing pastel theme for the high-spirited!
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24

--- a/src/catppuccin-frappe.conf
+++ b/src/catppuccin-frappe.conf
@@ -1,47 +1,43 @@
 #
 #  catppuccin.conf
-#  
+#
 #  Copyright 2022 waxxx333 <waxxx@WindowsXP>
 #  Reference the filetypes files before editing this config file.
-# 
+#
 [theme_info]
-name=Catppuccin Frappe
-description=Soothing pastel theme for the high-spirited!
+name=Catppuccin Frappé
+description=Soothing pastel theme for Geany
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24
 
 [named_colors]
-mantle=#292c3c
-base=#303446
-surface0=#414559
-# 
-text=#c6d0f5
-subtext0=#A5ADCE
-subtext1=#B5BFE2
-#
-overlay2=#949CBB
-overlay1=#838BA7
-overlay0=#737994
-#
-blue=#8CAAEE
-sky=#99d1db
-teal=#81c8be
-#
-yellow=#e5c890
-#
-green=#a6d189
-#
-flamingo=#eebebe
-mauve=#ca9ee6
-pink=#f4b8e4
-maroon=#ea999c
-red=#e78284
-peach=#ef9f76
 rosewater=#f2d5cf
-lavender=#babbf1
+flamingo=#eebebe
+pink=#f4b8e4
+mauve=#ca9ee6
+red=#e78284
+maroon=#ea999c
+peach=#ef9f76
+yellow=#e5c890
+green=#a6d189
+teal=#81c8be
+sky=#99d1db
 sapphire=#85c1dc
-
+blue=#8caaee
+lavender=#babbf1
+text=#c6d0f5
+subtext1=#b5bfe2
+subtext0=#a5adce
+overlay2=#949cbb
+overlay1=#838ba7
+overlay0=#737994
+surface2=#626880
+surface1=#51576d
+surface0=#414559
+base=#303446
+mantle=#292c3c
+crust=#232634
 
 [named_styles]
 operator=blue
@@ -94,7 +90,7 @@ keyword_3=peach
 keyword_4=keyword_2
 
 identifier=sky;;false;false
-# main 
+# main
 identifier_1=subtext0;;false;false
 identifier_2=default
 identifier_3=identifier_2

--- a/src/catppuccin-latte.conf
+++ b/src/catppuccin-latte.conf
@@ -1,47 +1,43 @@
 #
 #  catppuccin.conf
-#  
+#
 #  Copyright 2022 waxxx333 <waxxx@WindowsXP>
 #  Reference the filetypes files before editing this config file.
-# 
+#
 [theme_info]
 name=Catppuccin Latte
-description=Soothing pastel theme for the high-spirited!
+description=Soothing pastel theme for Geany
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24
 
 [named_colors]
-mantle=#e6e9ef
-base=#eff1f5
-surface0=#ccd0da
-# 
-text=#4c4f69
-subtext0=#6C6F85
-subtext1=#5C5F77
-#
-overlay2=#7C7F93
-overlay1=#8C8FA1
-overlay0=#9CA0B0
-#
-blue=#1E66F5
-sky=#04a5e5
-teal=#179299
-#
-yellow=#df8e1d
-#
-green=#40a02b
-#
-flamingo=#dd7878
-mauve=#8839ef
-pink=#ea76cb
-maroon=#e64553
-red=#d20f39
-peach=#fe640b
 rosewater=#dc8a78
-lavender=#7287fd
+flamingo=#dd7878
+pink=#ea76cb
+mauve=#8839ef
+red=#d20f39
+maroon=#e64553
+peach=#fe640b
+yellow=#df8e1d
+green=#40a02b
+teal=#179299
+sky=#04a5e5
 sapphire=#209fb5
-
+blue=#1e66f5
+lavender=#7287fd
+text=#4c4f69
+subtext1=#5c5f77
+subtext0=#6c6f85
+overlay2=#7c7f93
+overlay1=#8c8fa1
+overlay0=#9ca0b0
+surface2=#acb0be
+surface1=#bcc0cc
+surface0=#ccd0da
+base=#eff1f5
+mantle=#e6e9ef
+crust=#dce0e8
 
 [named_styles]
 operator=blue
@@ -94,7 +90,7 @@ keyword_3=peach
 keyword_4=keyword_2
 
 identifier=sky;;false;false
-# main 
+# main
 identifier_1=subtext0;;false;false
 identifier_2=default
 identifier_3=identifier_2

--- a/src/catppuccin-latte.conf
+++ b/src/catppuccin-latte.conf
@@ -6,7 +6,7 @@
 #
 [theme_info]
 name=Catppuccin Latte
-description=Soothing pastel theme for Geany
+description=Soothing pastel theme for the high-spirited!
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24

--- a/src/catppuccin-macchiato.conf
+++ b/src/catppuccin-macchiato.conf
@@ -1,47 +1,43 @@
 #
 #  catppuccin.conf
-#  
+#
 #  Copyright 2022 waxxx333 <waxxx@WindowsXP>
 #  Reference the filetypes files before editing this config file.
-# 
+#
 [theme_info]
 name=Catppuccin Macchiato
-description=Soothing pastel theme for the high-spirited!
+description=Soothing pastel theme for Geany
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24
 
 [named_colors]
-mantle=#1e2030
-base=#24273a
-surface0=#363a4f
-# 
-text=#cad3f5
-subtext0=#A5ADCB
-subtext1=#B8C0E0
-#
-overlay2=#939AB7
-overlay1=#8087A2
-overlay0=#6E738D
-#
-blue=#8AADF4
-sky=#91d7e3
-teal=#8bd5ca
-#
-yellow=#eed49f
-#
-green=#a6da95
-#
-flamingo=#f0c6c6
-mauve=#c6a0f6
-pink=#f5bde6
-maroon=#ee99a0
-red=#ed8796
-peach=#f5a97f
 rosewater=#f4dbd6
-lavender=#b7bdf8
+flamingo=#f0c6c6
+pink=#f5bde6
+mauve=#c6a0f6
+red=#ed8796
+maroon=#ee99a0
+peach=#f5a97f
+yellow=#eed49f
+green=#a6da95
+teal=#8bd5ca
+sky=#91d7e3
 sapphire=#7dc4e4
-
+blue=#8aadf4
+lavender=#b7bdf8
+text=#cad3f5
+subtext1=#b8c0e0
+subtext0=#a5adcb
+overlay2=#939ab7
+overlay1=#8087a2
+overlay0=#6e738d
+surface2=#5b6078
+surface1=#494d64
+surface0=#363a4f
+base=#24273a
+mantle=#1e2030
+crust=#181926
 
 [named_styles]
 operator=blue
@@ -94,7 +90,7 @@ keyword_3=peach
 keyword_4=keyword_2
 
 identifier=sky;;false;false
-# main 
+# main
 identifier_1=subtext0;;false;false
 identifier_2=default
 identifier_3=identifier_2

--- a/src/catppuccin-macchiato.conf
+++ b/src/catppuccin-macchiato.conf
@@ -6,7 +6,7 @@
 #
 [theme_info]
 name=Catppuccin Macchiato
-description=Soothing pastel theme for Geany
+description=Soothing pastel theme for the high-spirited!
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24

--- a/src/catppuccin-mocha.conf
+++ b/src/catppuccin-mocha.conf
@@ -6,7 +6,7 @@
 #
 [theme_info]
 name=Catppuccin Mocha
-description=Soothing pastel theme for Geany
+description=Soothing pastel theme for the high-spirited!
 version=0.2.5
 author=Isabelinc
 compat=1.22;1.23;1.23.1;1.24


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the `.conf` files directly, edit the `geany.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.

A few other things I noticed but I haven't changed here are:
- The license header at the top of each `.conf` file (and at the top of this new template) should be updated to Catppuccin to match the `LICENSE` file.
- The legacy version should probably be removed?